### PR TITLE
Update settings.ini to include new requirements

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -20,7 +20,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements
-requirements = numpy pandas altair
+requirements = numpy pandas altair scipy tqdm
 # Optional. Same format as setuptools console_scripts
 # console_scripts =
 


### PR DESCRIPTION
https://github.com/sci2lab/ml_tutorial/blob/47ea298a735aef56f862f444894e7fb77d339b04/settings.ini#L23

Just on reviewing this I believe scipy and tqdm are missing from this file. If you're open to pull requests I'm happy to make the change so tests aren't failing.